### PR TITLE
Allow Remove Containers command to pass if container does not exist.

### DIFF
--- a/src/main/resources/org/jenkinsci/plugins/dockerbuildstep/cmd/RemoveCommand/config-detail.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/dockerbuildstep/cmd/RemoveCommand/config-detail.jelly
@@ -5,4 +5,8 @@
         <f:textbox />
     </f:entry>
 
+    <f:entry field="ignoreIfNotFound" title="Ignore if not found" description="Do not fail this step if any of the containers are not found." >
+        <f:checkbox />
+    </f:entry>
+
 </j:jelly>


### PR DESCRIPTION
I have a situation where I need to ensure a container with a given name doesn't exist, but it may or may not be up and running. This adds a checkbox to not fail the step if the container doesn't exist. By default, the old behavior still happens.