### PR TITLE
Add missing files RemoveImageCommand and SaveImageCommand Jelly

### DIFF
--- a/src/main/resources/org/jenkinsci/plugins/dockerbuildstep/cmd/RemoveImageCommand/config-detail.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/dockerbuildstep/cmd/RemoveImageCommand/config-detail.jelly
@@ -1,0 +1,18 @@
+<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson"
+    xmlns:f="/lib/form">
+
+    <f:entry field="imageName" title="Image Name" description="Name from image to be removed." >
+        <f:textbox />
+    </f:entry>
+
+    <f:advanced>
+    	<f:entry field="imageId" title="Image Id" description="Id from image to be removed." >
+        	<f:textbox />
+    	</f:entry>
+    
+        <f:entry field="ignoreIfNotFound" title="Ignore if not found" description="Do not fail this step if the image is not found." >
+            <f:checkbox />
+        </f:entry>
+    </f:advanced>
+
+</j:jelly>

--- a/src/main/resources/org/jenkinsci/plugins/dockerbuildstep/cmd/SaveImageCommand/config-detail.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/dockerbuildstep/cmd/SaveImageCommand/config-detail.jelly
@@ -1,0 +1,26 @@
+<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson"
+    xmlns:f="/lib/form">
+
+    <f:entry field="imageName" title="Image" description="Image to be saved." >
+        <f:textbox />
+    </f:entry>
+    
+    <f:entry field="imageTag" title="Image Tag" description="Tag associated with image." >
+        <f:textbox />
+    </f:entry>
+    
+    <f:entry field="destination" title="Destination Folder" description="Destination Folder where the image to be saved." >
+        <f:textbox />
+    </f:entry>
+    
+    <f:entry field="filename" title="File Name" description="File Name for the archive." >
+        <f:textbox />
+    </f:entry>
+    
+    <f:advanced>
+        <f:entry field="ignoreIfNotFound" title="Ignore if not found" description="Do not fail this step if the image is not found." >
+            <f:checkbox />
+        </f:entry>
+    </f:advanced>
+
+</j:jelly>


### PR DESCRIPTION
Hello Vojtěch Juránek,

Last time I forgot to push the Jelly files associated with the class RemoveImageCommand and SaveImageCommand on my branch.
Can you integrate the missing files and publish a new version ?

Thanks.

Frédéric.

