### PR TITLE
Patch Save image with tag

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/dockerbuildstep/cmd/SaveImageCommand.java
+++ b/src/main/java/org/jenkinsci/plugins/dockerbuildstep/cmd/SaveImageCommand.java
@@ -105,7 +105,7 @@ public class SaveImageCommand extends DockerCommand {
 			final OutputStream output = new FileOutputStream(new File(
 					destinationRes + "/" + filenameRes));
 
-			IOUtils.copy(client.saveImageCmd(imageNameRes).withTag(imageTagRes)
+			IOUtils.copy(client.saveImageCmd(imageNameRes + ":" + imageTagRes)
 					.exec(), output);
 
 			IOUtils.closeQuietly(output);


### PR DESCRIPTION
Hy,

If the docker docker repository contains some image with differents tags,
for example: ubuntu:latest, ubuntu:1, ubuntu:2...
When you use the command Save image with a specific tag, in fact the archive contains all the different image with the same name, the tag is unrecognized.
I change the call to the library docker-java to solve the problem.

Best regards.

Frederic.