### PR TITLE
Clarifies format for BuildArgs parameter in description

### DIFF
--- a/src/main/resources/org/jenkinsci/plugins/dockerbuildstep/cmd/CreateImageCommand/config-detail.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/dockerbuildstep/cmd/CreateImageCommand/config-detail.jelly
@@ -17,7 +17,7 @@
             <f:checkbox />
         </f:entry>
 
-        <f:entry field="buildArgs" title="Build arguments, e.g. http_proxy=http://1.2.3.4:4321">
+        <f:entry field="buildArgs" title="List of build arguments, separated by comma, semi-colon or pipe (e.g. http_proxy=http://1.2.3.4:4321;foo=bar)">
             <f:textbox default="" />
         </f:entry>
 


### PR DESCRIPTION
Previuosly, I had to check the source code to see what separators where allowed (my first try, for instance, was whitespace)